### PR TITLE
Update publish pipeline to trigger on package.json change

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,28 +1,19 @@
 name: Publish to npm
 
 on:
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: Version bump type
-        required: true
-        default: patch
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
+  push:
+    branches:
+      - master
+    paths:
+      - package.json
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -34,13 +25,6 @@ jobs:
 
       - name: Build
         run: npm run build
-
-      - name: Bump version
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          npm version ${{ github.event.inputs.bump }} -m "chore: bump version to %s [skip ci]"
-          git push --follow-tags
 
       - name: Publish
         run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary
- Removed manual workflow_dispatch trigger and version bump logic
- Publish now triggers automatically when `package.json` changes on `master`
- No secrets or bot push permissions needed — uses npm Trusted Publisher (OIDC)

## How it works
Bump the version in `package.json` as part of a normal PR. When it merges to `master`, the publish workflow fires automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)