### PR TITLE
chore: bump version to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agility/content-sync",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "JavaScript SDK for synchronizing content from Agility CMS",
   "main": "dist/agility-sync-sdk.node.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps version from `1.2.0` → `1.2.1`
- Merging this will automatically trigger the npm publish pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)