### PR TITLE
fix: remove registry-url to fix Trusted Publisher auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Removes `registry-url` from `actions/setup-node` which was causing npm to publish unauthenticated
- `registry-url` writes an `.npmrc` expecting `NODE_AUTH_TOKEN` — without it set, requests are unauthenticated and npm returns 404
- With npm Trusted Publishers, npm handles OIDC auth natively so `registry-url` is not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)