### PR TITLE
chore: bump version to 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agility/content-sync",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "JavaScript SDK for synchronizing content from Agility CMS",
   "main": "dist/agility-sync-sdk.node.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps version from `1.2.1` → `1.2.2`
- Merging this will automatically trigger the npm publish pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)