### PR TITLE
fix: restore registry-url for npm Trusted Publisher OIDC auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Restores `registry-url: https://registry.npmjs.org` to `actions/setup-node`
- Without it npm has no registry context for the OIDC token exchange and returns `ENEEDAUTH`
- The original 404 was because the Trusted Publisher wasn't configured yet — now that it is, this should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)