### PR TITLE
fix: upgrade npm so Trusted Publisher OIDC works + bump 1.2.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org
 
       - name: Upgrade npm for Trusted Publisher OIDC support
         run: npm install -g npm@latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           node-version: 20
 
+      - name: Upgrade npm for Trusted Publisher OIDC support
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agility/content-sync",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "JavaScript SDK for synchronizing content from Agility CMS",
   "main": "dist/agility-sync-sdk.node.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Node 20 ships npm 10.8.2; Trusted Publisher OIDC requires **npm 11.5.1+**, which is why 1.2.1 and 1.2.2 publishes died with `ENEEDAUTH`
- Adds `npm install -g npm@latest` before `npm ci` so the publish step uses an OIDC-capable CLI
- Bumps version to 1.2.3 so the merge of this PR triggers the publish workflow and validates the fix end-to-end

## Verification (Trusted Publisher already configured on npmjs.com — confirmed by @joelvarty)
- [ ] Merge this PR
- [ ] Confirm the `Publish to npm` run completes successfully
- [ ] Confirm `@agility/content-sync@1.2.3` is on npmjs.com with a provenance attestation

🤖 Generated with [Claude Code](https://claude.com/claude-code)